### PR TITLE
Set `static` tag for static loaded contexts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # jsonld-document-loader
 
+## 1.1.0 - 2020-11-xx
+
+### Added
+- Set `static` tag for statically loaded contexts.
+
 ## 1.0.0 - 2019-10-18
 
 - See git history for changes.

--- a/lib/JsonLdDocumentLoader.js
+++ b/lib/JsonLdDocumentLoader.js
@@ -24,7 +24,8 @@ class JsonLdDocumentLoader {
       return {
         contextUrl: null,
         document,
-        documentUrl: url
+        documentUrl: url,
+        tag: 'static'
       };
     }
     throw new Error(`Document not found in document loader: ${url}`);


### PR DESCRIPTION
This tag allows a JSON-LD processor such as jsonld.js to cache a resolved context for statically loaded documents so it needn't be loaded or reprocessed multiple times.